### PR TITLE
Update projects to .net standard 2.0

### DIFF
--- a/KenticoCloud.Personalization.AspNetCore/KenticoCloud.Personalization.AspNetCore.csproj
+++ b/KenticoCloud.Personalization.AspNetCore/KenticoCloud.Personalization.AspNetCore.csproj
@@ -7,7 +7,7 @@
     <Title>Kentico Cloud Personalization AspNetCore SDK</Title>
     <NeutralLanguage>en-us</NeutralLanguage>
     <Authors>Kentico Software</Authors>
-    <TargetFrameworks>net451;netstandard1.3</TargetFrameworks>
+    <TargetFrameworks>net451;netstandard2.0</TargetFrameworks>
     <AssemblyName>KenticoCloud.Personalization.AspNetCore</AssemblyName>
     <PackageId>KenticoCloud.Personalization.AspNetCore</PackageId>
     <PackageTags>kentico;mvc;aspnetcore;aspnetcoremvc</PackageTags>

--- a/KenticoCloud.Personalization.Tests/KenticoCloud.Personalization.Tests.csproj
+++ b/KenticoCloud.Personalization.Tests/KenticoCloud.Personalization.Tests.csproj
@@ -5,14 +5,12 @@
     <Copyright>(c) 2016 Kentico Software. All rights reserved.</Copyright>
     <AssemblyTitle>Kentico Cloud Personalization SDK tests</AssemblyTitle>
     <Authors>Kentico Software</Authors>
-    <TargetFramework>netcoreapp1.0</TargetFramework>
     <AssemblyName>KenticoCloud.Personalization.Tests</AssemblyName>
     <PackageId>KenticoCloud.Personalization.Tests</PackageId>
     <GenerateRuntimeConfigurationFiles>true</GenerateRuntimeConfigurationFiles>
     <PackageLicenseUrl>https://github.com/Kentico/personalization-sdk-net/blob/master/LICENSE</PackageLicenseUrl>
     <RepositoryType>git</RepositoryType>
     <RepositoryUrl>https://github.com/Kentico/personalization-sdk-net.git</RepositoryUrl>
-    <RuntimeFrameworkVersion>1.0.4</RuntimeFrameworkVersion>
     <NetStandardImplicitPackageVersion>1.6.1</NetStandardImplicitPackageVersion>
     <GenerateAssemblyTitleAttribute>false</GenerateAssemblyTitleAttribute>
     <GenerateAssemblyDescriptionAttribute>false</GenerateAssemblyDescriptionAttribute>
@@ -21,23 +19,20 @@
     <GenerateAssemblyCopyrightAttribute>false</GenerateAssemblyCopyrightAttribute>
     <GenerateAssemblyVersionAttribute>false</GenerateAssemblyVersionAttribute>
     <GenerateAssemblyFileVersionAttribute>false</GenerateAssemblyFileVersionAttribute>
+    <TargetFramework>netcoreapp2.1</TargetFramework>
   </PropertyGroup>
-
   <ItemGroup>
     <ProjectReference Include="..\KenticoCloud.Personalization\KenticoCloud.Personalization.csproj" />
     <ProjectReference Include="..\KenticoCloud.Personalization.AspNetCore\KenticoCloud.Personalization.AspNetCore.csproj" />
   </ItemGroup>
-
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.0.0" />
-    <PackageReference Include="NUnit" Version="3.7.1" />
+    <PackageReference Include="Microsoft.AspNetCore.Mvc" Version="2.1.2" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.8.0" />
     <PackageReference Include="NSubstitute" Version="3.1.0" />
-    <PackageReference Include="Microsoft.AspNetCore.Mvc" Version="1.1.1" />
-    <PackageReference Include="NUnit3TestAdapter" Version="3.8.0" />
+    <PackageReference Include="NUnit" Version="3.10.1" />
+    <PackageReference Include="NUnit3TestAdapter" Version="3.10.0" />
   </ItemGroup>
-
   <ItemGroup>
     <Service Include="{82a7f48d-3b50-4b1e-b82e-3ada8210c358}" />
   </ItemGroup>
-
 </Project>

--- a/KenticoCloud.Personalization/KenticoCloud.Personalization.csproj
+++ b/KenticoCloud.Personalization/KenticoCloud.Personalization.csproj
@@ -7,7 +7,7 @@
     <NeutralLanguage>en-us</NeutralLanguage>
     <Authors>Kentico Software</Authors>
     <Title>Kentico Cloud Personalization SDK</Title>
-    <TargetFrameworks>netstandard1.3;net451</TargetFrameworks>
+    <TargetFrameworks>net451;netstandard2.0</TargetFrameworks>
     <AssemblyName>KenticoCloud.Personalization</AssemblyName>
     <PackageId>KenticoCloud.Personalization</PackageId>
     <PackageTags>kentico</PackageTags>


### PR DESCRIPTION
### Motivation

Fixes issue https://github.com/Kentico/personalization-sdk-net/issues/18

I left `net451` as a target framework since it had a lower .net standard than 1.3. 

Ideally I wanted to leave .net standard 1.3 as a target framework too so that people with a `net46` or `netcore1.0` apps can use the package but the issue mentioned to replace 1.3 standard with 2.0. 

### Checklist

- [x] Code follows coding conventions held in this repo
- [ ] Automated tests have been added
- [x] Tests are passing
- [x] Docu has been updated (if applicable)
- [x] Temporary settings (e.g. project ID used during development and testing) have been reverted to defaults

### How to test

No functional changes so shouldn't require any. Does it?